### PR TITLE
fix: details要素やコードブロック内の見出しを目次から除外

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,10 +1,10 @@
 // Zenn Scrap TOC Extension - Main Content Script
-// Version: 0.1.1
+// Version: 0.1.2
 
 (function() {
   'use strict';
 
-  console.log('[Zenn Scrap TOC] Extension loaded - v0.1.1');
+  console.log('[Zenn Scrap TOC] Extension loaded - v0.1.2');
 
   // グローバル変数でObserverと状態を管理
   let tocScrollObserver = null;
@@ -161,6 +161,16 @@
     const elements = document.querySelectorAll(selector);
 
     elements.forEach((element) => {
+      // details要素内の見出しを除外
+      if (element.closest('details')) {
+        return;
+      }
+
+      // pre/code要素内の見出しを除外
+      if (element.closest('pre') || element.closest('code')) {
+        return;
+      }
+
       const level = parseInt(element.tagName.charAt(1));
       const text = element.textContent.replace(/^#\s*/, '').trim();
       let id = element.id;
@@ -271,7 +281,7 @@
     panel.className = `zenn-scrap-toc ${tocSettings.isExpanded ? 'expanded' : 'collapsed'}`;
 
     // バージョン表示（デバッグ用）
-    panel.dataset.version = '0.1.1';
+    panel.dataset.version = '0.1.2';
 
     // ヘッダー部分
     const header = document.createElement('div');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Zenn Scrap TOC",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "ZennのScrapページに目次機能を追加します",
   "permissions": [
     "storage"


### PR DESCRIPTION
## 概要
Issue #1 で報告された、`<details>`要素やコードブロック内の見出しも目次に含まれてしまう問題を修正しました。

## 変更内容
- `collectHeadings()`関数に除外処理を追加
  - details要素内の見出しを目次から除外
  - pre/code要素内の見出しを目次から除外
- バージョンを0.1.1から0.1.2に更新

## 技術的詳細
`element.closest()`メソッドを使用して、見出し要素が`details`、`pre`、`code`要素の子孫かどうかをチェックし、該当する場合は目次への追加をスキップするようにしました。

## レビュー確認事項

### 🎯 このPRで特に確認してほしいポイント
- `details`要素内の見出しが正しく除外されているか
- コードブロック内のMarkdown記法（# 見出し）が目次に含まれていないか
- 通常の見出しは引き続き正常に目次に表示されるか

### 📱 ブラウザでの動作確認
- [ ] Zenn Scrapページで拡張機能が正常に動作する
- [ ] details要素を含むScrapで、details内の見出しが目次に表示されないことを確認
- [ ] コードブロック内にMarkdown記法の見出しを含むScrapで、それが目次に表示されないことを確認
- [ ] 通常の見出し（h1〜h3）が正しく目次に表示される

### ⚠️ エッジケースの確認
- [ ] ネストされたdetails要素がある場合でも正常に動作する
- [ ] インラインコード（`code`要素）内のテキストが目次に表示されない
- [ ] 複数のdetails要素がある場合でも正常に動作する

### 🔍 既存機能への影響確認
- [ ] 目次の階層構造が正しく表示される
- [ ] スクロールスパイ機能（現在位置のハイライト）が正常に動作する
- [ ] 目次の展開/折りたたみ機能が正常に動作する

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)