### PR TITLE
perf: MutationObserverを活用して目次の表示速度を大幅に改善

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Zenn Scrap TOC",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "ZennのScrapページに目次機能を追加します",
   "permissions": [
     "storage"


### PR DESCRIPTION
## 概要
Issue #3 で提案された、MutationObserverを活用した目次表示速度の改善を実装しました。
固定遅延に依存せず、DOM要素の出現を監視することで、コンテンツが利用可能になり次第すぐに目次を表示します。

## 変更内容

### 🚀 パフォーマンス改善
- **初回表示**: 500ms → **即座〜100ms**
- **ページ遷移**: 800ms → **即座〜100ms**  
- **動的更新**: 500ms → **100ms**

### 🔧 技術的実装
1. **早期初期化Observer** (`setupEarlyInitObserver()`)
   - 見出し要素の出現を監視
   - 20msの短いデバウンスで高速応答
   - 5秒のタイムアウトで自動クリーンアップ

2. **遅延時間の最適化**
   - フォールバック: 100ms（最小限）
   - URLポーリング: 300ms（500msから短縮）
   - リンククリック後: 200ms（500msから短縮）

3. **スマートな初期化**
   - 既に見出しが存在する場合は即座に初期化
   - 見出しがない場合はObserverで監視
   - フォールバック機構で確実性を担保

## 動作の流れ

```mermaid
graph TD
    A[ページアクセス] --> B{見出し要素あり?}
    B -->|Yes| C[即座に初期化]
    B -->|No| D[MutationObserver設定]
    D --> E[見出し検出を監視]
    E --> F{見出し検出?}
    F -->|Yes| G[即座に初期化]
    F -->|No| H[100ms後フォールバック]
```

## テスト項目

### ✅ 基本動作
- [ ] Scrapページで目次が表示される
- [ ] 目次表示が以前より速くなっている
- [ ] 「ふわっと」遅れる感じが改善されている

### ✅ 各シナリオでの動作確認
- [ ] 初回アクセス時に素早く目次が表示される
- [ ] ページ遷移時に素早く目次が表示される
- [ ] リロード時に素早く目次が表示される
- [ ] 見出しがないページでも正常に動作する

### ✅ 動的更新の確認
- [ ] Scrap追記時に新しい見出しが目次に反映される
- [ ] 見出しの編集が目次に反映される
- [ ] 見出しの削除が目次に反映される

### ✅ エッジケース
- [ ] 遅いネットワーク環境でも動作する
- [ ] 見出しが段階的にロードされる場合も正常動作
- [ ] ページ遷移を繰り返しても正常動作

### ✅ 既存機能の確認
- [ ] details要素内の見出しは引き続き除外される
- [ ] コードブロック内の見出しは引き続き除外される
- [ ] スクロールスパイ機能が正常に動作する
- [ ] 目次の展開/折りたたみが正常に動作する

## バージョン
0.1.2 → **0.2.0**（メジャーパフォーマンス改善）

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)