### PR TITLE
fix: 見出しが空の場合にappendChildでTypeErrorが発生する問題を修正

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,10 +1,10 @@
 // Zenn Scrap TOC Extension - Main Content Script
-// Version: 0.2.0
+// Version: 0.2.1
 
 (function() {
   'use strict';
 
-  console.log('[Zenn Scrap TOC] Extension loaded - v0.2.0');
+  console.log('[Zenn Scrap TOC] Extension loaded - v0.2.1');
 
   // グローバル変数でObserverと状態を管理
   let tocScrollObserver = null;
@@ -235,7 +235,10 @@
   // TOCのHTMLを生成
   function createTocHtml(tocStructure, currentId = null) {
     if (tocStructure.length === 0) {
-      return '<div class="zenn-toc-empty">見出しが見つかりません</div>';
+      const emptyDiv = document.createElement('div');
+      emptyDiv.className = 'zenn-toc-empty';
+      emptyDiv.textContent = '見出しが見つかりません';
+      return emptyDiv;
     }
 
     function buildList(items, depth = 0) {
@@ -292,7 +295,7 @@
     panel.className = `zenn-scrap-toc ${tocSettings.isExpanded ? 'expanded' : 'collapsed'}`;
 
     // バージョン表示（デバッグ用）
-    panel.dataset.version = '0.2.0';
+    panel.dataset.version = '0.2.1';
 
     // ヘッダー部分
     const header = document.createElement('div');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Zenn Scrap TOC",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "ZennのScrapページに目次機能を追加します",
   "permissions": [
     "storage"


### PR DESCRIPTION
## 概要
Issue #5 の修正：見出しが存在しないページでTypeErrorが発生する問題を解消

## 変更内容
- `createTocHtml`関数を修正し、見出しが空の場合でも常にDOM要素を返すように変更
- バージョンを0.2.0から0.2.1へアップデート

## 修正前の問題
見出しが存在しないZennスクラップページで以下のエラーが発生：
```
Uncaught TypeError: Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'.
at content.js:353
```

## 修正内容の詳細
```javascript
// 修正前：文字列を返していた
if (tocStructure.length === 0) {
  return '<div class="zenn-toc-empty">見出しが見つかりません</div>';
}

// 修正後：DOM要素を返すように変更
if (tocStructure.length === 0) {
  const emptyDiv = document.createElement('div');
  emptyDiv.className = 'zenn-toc-empty';
  emptyDiv.textContent = '見出しが見つかりません';
  return emptyDiv;
}
```

## テスト項目
- [x] 見出しがないページで目次パネルが正しく表示される
- [x] エラーが発生しないことを確認
- [x] 「見出しが見つかりません」メッセージが適切に表示される
- [x] 既存の目次表示機能に影響がないことを確認

## レビュー確認事項

### 🎯 このPRで特に確認してほしいポイント
- createTocHtml関数がすべてのケースでDOM要素を返すようになったか
- エラーハンドリングが適切か

### 📱 ブラウザでの動作確認
- [ ] 見出しのないスクラップページで目次パネルが正常に表示される
- [ ] コンソールにエラーが出ていない
- [ ] 見出しのあるページでも正常に動作する

### ⚠️ エッジケースの確認
- [ ] ページロード中に見出しが追加される場合の動作
- [ ] 見出しが動的に削除された場合の動作

### 🔍 既存機能への影響確認
- [ ] 目次の展開/折りたたみ機能が正常に動作する
- [ ] スクロールスパイ機能が正常に動作する
- [ ] MutationObserverによる動的更新が正常に動作する

Closes #5