### PR TITLE
fix: blockquoteやaside内の見出しを目次から除外

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,10 +1,10 @@
 // Zenn Scrap TOC Extension - Main Content Script
-// Version: 0.2.3
+// Version: 0.2.4
 
 (function() {
   'use strict';
 
-  console.log('[Zenn Scrap TOC] Extension loaded - v0.2.3');
+  console.log('[Zenn Scrap TOC] Extension loaded - v0.2.4');
 
   // グローバル変数でObserverと状態を管理
   let tocScrollObserver = null;
@@ -226,6 +226,16 @@
         return;
       }
 
+      // blockquote要素内の見出しを除外
+      if (element.closest('blockquote')) {
+        return;
+      }
+
+      // aside要素内の見出しを除外
+      if (element.closest('aside')) {
+        return;
+      }
+
       const level = parseInt(element.tagName.charAt(1));
       const text = element.textContent.replace(/^#\s*/, '').trim();
       let id = element.id;
@@ -342,7 +352,7 @@
     panel.className = `zenn-scrap-toc ${tocSettings.isExpanded ? 'expanded' : 'collapsed'}`;
 
     // バージョン表示（デバッグ用）
-    panel.dataset.version = '0.2.3';
+    panel.dataset.version = '0.2.4';
 
     // ヘッダー部分
     const header = document.createElement('div');

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Zenn Scrap TOC",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "ZennのScrapページに目次機能を追加します",
   "permissions": [
     "storage"


### PR DESCRIPTION
## 概要
Issue #9: blockquoteやaside要素内の見出しが目次に含まれてしまう問題を修正しました。

## 変更内容
- `collectHeadings`関数に、blockquote要素内の見出しを除外するフィルタリングを追加
- `collectHeadings`関数に、aside要素内の見出しを除外するフィルタリングを追加
- バージョンを0.2.3から0.2.4に更新（PATCH）

## 修正前後の動作

### 修正前
- blockquote内の見出し（引用文内の見出し）も目次に表示されていました
- aside内の見出し（補足情報内の見出し）も目次に表示されていました

### 修正後
- blockquote内の見出しは目次から除外されます
- aside内の見出しは目次から除外されます
- 記事本文の見出しのみが目次に表示されます

## テスト項目
### 🎯 このPRで特に確認してほしいポイント
- blockquoteとaside内の見出しが目次から正しく除外されているか
- 通常の記事本文の見出しは引き続き正しく表示されるか

### 📱 ブラウザでの動作確認
- [ ] Zennのスクラップページで拡張機能が正常に動作する
- [ ] blockquote内にh1/h2/h3タグがある場合、それらが目次に表示されない
- [ ] aside内にh1/h2/h3タグがある場合、それらが目次に表示されない
- [ ] 記事本文のh1/h2/h3タグは正しく目次に表示される
- [ ] 既存のdetails、pre、code要素内の見出し除外も引き続き機能する

### ⚠️ エッジケースの確認
- [ ] ネストされたblockquote（blockquote内のblockquote）でも正しく動作する
- [ ] blockquoteとasideが混在するページでも正しく動作する
- [ ] 動的に追加されるblockquote/aside内の見出しも正しく除外される

### 🔍 既存機能への影響確認
- [ ] スクロールスパイ機能が正常に動作する
- [ ] 目次の展開/折りたたみが正常に動作する
- [ ] SPA遷移時の目次更新が正常に動作する

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)